### PR TITLE
Add required SOCKET_FILE variable to memcached_node_ng's warden_ctl

### DIFF
--- a/jobs/memcached_node_ng/templates/.#warden_ctl
+++ b/jobs/memcached_node_ng/templates/.#warden_ctl
@@ -1,1 +1,0 @@
-rubenkoster@Admins-MacBook-Pro-3.local.15111

--- a/jobs/memcached_node_ng/templates/warden_ctl
+++ b/jobs/memcached_node_ng/templates/warden_ctl
@@ -1,5 +1,7 @@
 #!/bin/bash
-
+<%
+node = properties.mongodb_node
+%>
 JOB_DIR=/var/vcap/jobs/memcached_node_ng
 PKG_DIR=/var/vcap/packages/memcached_node_ng
 MEMCACHED_BIN_DIR=/var/vcap/packages/memcached/bin


### PR DESCRIPTION
When trying to deploy the memcached_node_ng the job refuses to start. 
Inspecting warden's logfile gives us the following information:
`tail /var/vcap/sys/log/monit/warden_ctl.err.log`

```
Usage: grep [OPTION]... PATTERN [FILE]...
Try `grep --help' for more information.
```

It turns out that the [SOCKET_FILE](https://github.com/cloudfoundry/cf-services-contrib-release/blob/master/src/common/services/utils.sh#L65) variable was not set. 

This fix is inspired by [this line](https://github.com/cloudfoundry/cf-release/blob/master/jobs/mongodb_node_ng/templates/warden_ctl#L13).
