### PR TITLE
Fix blobs.yml object_ids; remove unused blobs

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,61 +1,38 @@
 ---
 sqlite/sqlite-autoconf-3070500.tar.gz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2ExMWUxMjEwMDRlNGU3ZDUxMWY4MjEwNGYzMDY4%0ANjYxY2NmYSIsInNpZyI6ImRUWDZ0ejVOd0lRNlhvWWE2S0V3RFRUdHhvST0i%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca11e121004e4e7d511f82104f3068661ccfa
   sha: 4e1338497b8da50b84307191bb3418e9ec5715d7
   size: 1551070
-node/node-v0.6.8.tar.gz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2E1MWUxMjIwMDRlNGU4ZWM2ODQwNzcwNGYzMDY4%0ANmM2NjU0MyIsInNpZyI6IlJONFNPTkxUMEhoaUlxRk03V2VrVkIweVZtYz0i%0AfQ==%0A
-  sha: c3f755b5dfd0de3f306d06573fa9433d845623dd
-  size: 10488841
 node/node-v0.4.12.tar.gz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2E2MWUxMjEwMDRlNGU3ZDUxZDk1MGUwNGYzMDY4%0ANzYwZjY3ZiIsInNpZyI6ImI2clVsYnpCbFllWGhOMjUwbSt4Tmk2S2pVTT0i%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca61e121004e4e7d51d950e04f3068760f67f
   sha: 1c6e34b90ad6b989658ee85e0d0cb16797b16460
   size: 12421469
-ruby/rubygems-1.7.2.tgz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2ExMWUxMjIwMDRlNGU4ZWM2NDg0MzEwNGYzMDY5%0AMDc2OWNkMiIsInNpZyI6IklQQk1BNmxodmNGTHNiTDRkcFR5eDRyWXljRT0i%0AfQ==%0A
-  sha: d878ae52f40eb71e59708afc57303172f0327fad
-  size: 245606
 ruby/ruby-1.9.2-p180.tar.gz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2EyMWUxMjEwMDRlNGU3ZDUxMWY1NTMwNGYzMDY5%0AMGM4OGZkOSIsInNpZyI6IkE1VlllWVduMVpadFNHbGRpeGM1STgzTU9Jaz0i%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca21e121004e4e7d511f55304f30690c88fd9
   sha: 6a482bc07239b37bcadf68dda63c65d20dc19ebe
   size: 11158935
-ruby/rake-0.8.7.gem:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2E1MWUxMjEwMDRlNGU3ZDUxOTA2Y2QwNGYzMDY5%0AMWM0NWFlMCIsInNpZyI6Img0aWh0QVo0cGNrWWxsYXRpZUhTU251TzArUT0i%0AfQ==%0A
-  sha: 91daad079d404b68a7dd179716b9fdd0c195144c
-  size: 104960
-node/npm-v1.0.106.tgz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2ExMWUxMjIwMDRlNGU4ZWM2NDg0MzEwNGY2NmFj%0AMDdjNjdiZCIsInNpZyI6IkhrR0RjWUFrdU94MFJBaGZlTVJTYlk0dFVBWT0i%0AfQ==%0A
-  sha: ef1830b68a1537a606dae3bdee71fd1153d7e71e
 memcached/libevent-2.0.19-stable.tar.gz:
-  object_id: eyJzaWciOiJIaWtwTHBwS3QyMjZQUDdycHJuTlFYQWlFRDA9Iiwib2lkIjoi%0ANGU0ZTc4YmNhMTFlMTIyMDA0ZTRlOGVjNjQ4NDMxMDRmYjZkNjI0M2ViZmMi%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca11e122004e4e8ec64843104fb6d6243ebfc
   sha: 28c109190345ce5469add8cf3f45c5dd57fe2a85
   size: 842961
 memcached/memcached-1.4.13.tar.gz:
-  object_id: eyJzaWciOiIyRy9MK0JsbEtTYnF2SjgwLzZ2Qm5qbE93VDA9Iiwib2lkIjoi%0ANGU0ZTc4YmNhMTFlMTIyMjA0ZTRlOTg2MzhiNzYzMDRmYjZkNjI4ZDI4Y2Ii%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca11e122204e4e98638b76304fb6d628d28cb
   size: 320751
   sha: d9a48d222de53a2603fbab6156d48d0e8936ee92
 ruby/rubygems-1.8.24.tgz:
-  object_id: eyJzaWciOiJkZkdFQ2k0aXFua1pESmZvalNKa09tSGtySkU9Iiwib2lkIjoi%0ANGU0ZTc4YmNhNDFlMTIyMjA0ZTRlOTg2M2QwNzYzMDRmYTFjYzI4Nzk3YTki%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca41e122204e4e9863d076304fa1cc28797a9
   sha: 30f27047e74f7943117736a0d3e224994fee0905
   size: 380101
-git/git-1.7.11.2.tar.gz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2E2MWUxMjEyMDRlNGU4NmVlYmU1OTEwNGZmZjEy%0AZDdlNDljNiIsInNpZyI6IkdvaUhZdDA2OFpDcUowVzhYOFdLYUVyV2RLRT0i%0AfQ==%0A
-  sha: f67b4f6c0277250411c6872ae7b8a872ae11d313
-  size: 4015780
-node/node-v0.8.2.tar.gz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2E2MWUxMjIyMDRlNGU5ODY0M2Q5YWUwNGZmYjVk%0AOTY1MWJhMCIsInNpZyI6ImpQUzhLRTFOWE5XbENkYnhUbjlPQU9wQ3JJbz0i%0AfQ==%0A
-  sha: 0e743d21b487151e67950f09198def058db19a1e
-  size: 11727164
 libyaml/yaml-0.1.4.tgz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2E1MWUxMjIwMDRlNGU4ZWM2ODQwNzcwNTExZDM1%0AZmZjOTFiZCIsInNpZyI6IlIwQk51U2ZSTVQ1czgzVHpPQkZBVVFxYjJWaz0i%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca51e122004e4e8ec6840770511d35ffc91bd
   sha: e0e5e09192ab10a607e3da2970db492118f560f2
   size: 471759
 ruby/bundler-1.2.1.gem:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2EzMWUxMjEyMDRlNGU4NmVlMzk2OTIwNTBhMTYy%0ANTJmMDUyZiIsInNpZyI6InZYOFl0dktMN3k5NWNHWTZnbnpVcFpHY2tUMD0i%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca31e121204e4e86ee39692050a16252f052f
   sha: 0cbe6ad7a41f064d6c11c1058465fffb1bd58069
   size: 226816
 ruby/ruby-1.9.3-p392.tar.gz:
-  object_id: eyJvaWQiOiI0ZTRlNzhiY2E2MWUxMjEyMDRlNGU4NmVlYmU1OTEwNTEzYTMy%0ANzA5NjhmMyIsInNpZyI6IlRXUWlidzkzcDQyVG1STEtnR1dIKzg5UHlqYz0i%0AfQ==%0A
+  object_id: rest/objects/4e4e78bca61e121204e4e86eebe5910513a3270968f3
   sha: ec75fcbd3b6b46ce6ec997ee4c86145b4abd5748
   size: 12557294
 postgres/postgres-9.0.3-1.amd64.tar.gz:


### PR DESCRIPTION
The object_ids come from an old cf-release
(circa c8992081a1a73bffceb6088a7a6a625b3689f919)
