### PR TITLE
Fix ng-services not able to start warden due to wrong rootfs

### DIFF
--- a/jobs/mongodb_node_ng/spec
+++ b/jobs/mongodb_node_ng/spec
@@ -30,6 +30,7 @@ packages:
   - mongodb18
   - mongodb20
   - mongodb22
+  - rootfs_lucid64
   - ruby
   - ruby_next
   - sqlite

--- a/jobs/mongodb_node_ng/templates/warden.yml.erb
+++ b/jobs/mongodb_node_ng/templates/warden.yml.erb
@@ -16,7 +16,7 @@ node = properties.mongodb_node
 server:
   container_klass: Warden::Container::Linux
   container_grace_time: ~
-  container_rootfs_path: /var/vcap/data/mongodb/warden/rootfs
+  container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/store/mongodb/containers
   unix_domain_permissions: 0777
   unix_domain_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>

--- a/jobs/rabbit_node_ng/spec
+++ b/jobs/rabbit_node_ng/spec
@@ -28,6 +28,7 @@ packages:
   - rabbitmq-2.4
   - rabbitmq-2.8
   - rabbitmq-3.0
+  - rootfs_lucid64
   - daylimit
   - ruby
   - ruby_next

--- a/jobs/rabbit_node_ng/templates/warden.yml.erb
+++ b/jobs/rabbit_node_ng/templates/warden.yml.erb
@@ -5,7 +5,7 @@ node = properties.rabbit_node
 server:
   container_klass: Warden::Container::Linux
   container_grace_time: ~
-  container_rootfs_path: /var/vcap/data/rabbit/warden/rootfs
+  container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/store/rabbit/containers
   unix_domain_permissions: 0777
   unix_domain_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>

--- a/jobs/redis_node_ng/spec
+++ b/jobs/redis_node_ng/spec
@@ -25,6 +25,7 @@ packages:
   - redis22
   - redis24
   - redis26
+  - rootfs_lucid64
   - ruby
   - ruby_next
   - sqlite

--- a/jobs/redis_node_ng/templates/warden.yml.erb
+++ b/jobs/redis_node_ng/templates/warden.yml.erb
@@ -14,7 +14,7 @@ node = properties.redis_node
 server:
   container_klass: Warden::Container::Linux
   container_grace_time: ~
-  container_rootfs_path: /var/vcap/data/redis/warden/rootfs
+  container_rootfs_path: /var/vcap/packages/rootfs_lucid64
   container_depot_path: /var/vcap/store/redis/containers
   unix_domain_permissions: 0777
   unix_domain_path: <%= node.warden_socket_path || "/tmp/warden.sock" %>


### PR DESCRIPTION
Apply fix from https://github.com/cloudfoundry/cf-services-contrib-release/pull/13
