### PR TITLE
Add `nats` options to sample manifests

### DIFF
--- a/examples/dns-all.yml
+++ b/examples/dns-all.yml
@@ -158,6 +158,13 @@ properties:
   cc:
     srv_api_uri: http://api.mycloud.com #CHANGE
 
+  nats:
+    address: 0.core.default.cf.bosh #CHANGE
+    port: 4222 #CHANGE
+    user: nats #CHANGE
+    password: NATS_PASSWORD #CHANGE
+    authorization_timeout: 5
+
   service_plans:
     mongodb:
       default:

--- a/examples/dns-postgresql.yml
+++ b/examples/dns-postgresql.yml
@@ -80,6 +80,13 @@ properties:
   cc:
     srv_api_uri: http://api.mycloud.com #CHANGE
 
+  nats:
+    address: 0.core.default.cf.bosh #CHANGE
+    port: 4222 #CHANGE
+    user: nats #CHANGE
+    password: NATS_PASSWORD #CHANGE
+    authorization_timeout: 5
+
   service_plans:
     postgresql:
       default:


### PR DESCRIPTION
I found that the manifest in the `examples` directory have no `nats` settings in them and I could not deploy the release with these samples.

Since these manifests are  used to deploy services as a standalone deployment, I think it would be great if they have sample `nats` config in them.
