### PR TITLE
Allow custom hp_service_type [swift]

### DIFF
--- a/examples/dns-all.yml
+++ b/examples/dns-all.yml
@@ -383,5 +383,6 @@ properties:
         hp_use_upass_auth_style: true
         hp_avl_zone: 'nova'
         hp_auth_version: "v2"
+        hp_service_type: "Object Storage"
 
 

--- a/jobs/swift_node/templates/fog.yml.erb
+++ b/jobs/swift_node/templates/fog.yml.erb
@@ -18,3 +18,4 @@
    :hp_use_upass_auth_style: <%= properties.swift_node.fog.storage.hp_use_upass_auth_style || true %>
    :hp_avl_zone: <%= properties.swift_node.fog.storage.hp_avl_zone || 'nova' %>
    :hp_auth_version: <%= properties.swift_node.fog.storage.hp_auth_version || "v2" %>
+   :hp_service_type: <%= properties.swift_node.fog.storage.hp_service_type %>


### PR DESCRIPTION
For our setup to work, we need the `hp_service_type` to be customizable. This PR makes it possible to define it in your bosh manifest. This PR depends on a corresponding PR for the source at anynines [[link](https://github.com/anynines/cf_swift_service/pull/3)].

Therefore I have added `"Object Storage"` to the example manifest as the default value for `hp_service_type`. This corresponds with the default that already existed in `Fog::Storage::HP` [[link](https://github.com/fog/fog/blob/master/lib/fog/hp/storage.rb#L324)]. The fix is backwards compatible, the option can be left out of the manifest without any troubles.
