### PR TITLE
make the paramter noscripting of mongodb configurable

### DIFF
--- a/jobs/mongodb_node_ng/templates/mongodb.conf.erb
+++ b/jobs/mongodb_node_ng/templates/mongodb.conf.erb
@@ -27,7 +27,7 @@ maxConns = <%= plan_enabled && plan_conf.max_clients && plan_conf.max_clients.to
 noprealloc = true
 
 # forbidden the server-side javascript execution
-noscripting = true
+noscripting = <%= properties.mongodb_node.noscripting || "true" %>
 
 # smallfiles = start first container file at 16MB, doubling 4 times.
 # so this = 240MB per user. (i.e. 16MB container + 32MB + 64MB + 128MB)


### PR DESCRIPTION
I have make the parameter "noscripting" configurable on mongodb by make the following changes. 
After doing this, you can add one line in your deployment yaml file like following to make "noscripting" parameter configurable:
mongodb_node:
    supported_versions: ["2.2"]
    default_version: "2.2"
    max_tmp: 900
-   noscripting: false
