### PR TITLE
add more rabbitMQ config parameters

### DIFF
--- a/examples/dns-all.yml
+++ b/examples/dns-all.yml
@@ -1,6 +1,6 @@
----
 name: cf-services-contrib
 director_uuid: DIRECTOR_UUID   # CHANGE
+---
 
 releases:
   - name: cf-services-contrib
@@ -177,6 +177,10 @@ properties:
           quota_files: 4
           quota_data_size: 240
           enable_journaling: true
+          bandwidth_quotas:
+            per_second: 1
+            per_day: 10
+            time_window: 86400          
           backup:
             enable: true
           lifecycle:
@@ -357,7 +361,8 @@ properties:
     supported_versions: ["3.0"]
     default_version: "3.0"
     max_tmp: 900
-
+    m_actions: ["restart"] #restarts crashed rabbitMQ nodes
+    
   swift_gateway:
     token: SWIFT_SERVICE_TOKEN # CHANGE - the token you use later with `cf create-service-auth-token`
     default_plan: "free"


### PR DESCRIPTION
add rabbitMQ config parameters to restart crashed instances and enhance the daylimit
