### PR TITLE
Update rabbit_node.rb

### DIFF
--- a/src/services/ng/rabbit/lib/rabbit_service/rabbit_node.rb
+++ b/src/services/ng/rabbit/lib/rabbit_service/rabbit_node.rb
@@ -299,6 +299,7 @@ class VCAP::Services::Rabbit::Node
       "vhost" => instance.vhost,
     }
     yield credentials
+    credentials["url"] = "amqp://#{credentials["user"]}:#{credentials["pass"]}@#{credentials["host"]}:#{credentials["port"]}/#{credentials["vhost"]}"
     credentials["uri"] = "amqp://#{credentials["user"]}:#{credentials["pass"]}@#{credentials["host"]}:#{credentials["port"]}/#{credentials["vhost"]}"
     credentials
   end


### PR DESCRIPTION
According to the documentation this field should be URI instead of URL. I created an issue for that in service-contrib-release project. This is a suggestion due to the fact that the other services as well as the central run.pivotal.io instance returns URI and not URL for a provisioned and configured service binding (http://docs.cloudfoundry.org/services/api.html#binding).

Detailed debugging and explanations can be found here: https://github.com/spring-projects/spring-cloud/issues/25
