### PR TITLE
Add uri to mongodb VCAP_SERVICES

### DIFF
--- a/src/services/ng/mongodb/lib/mongodb_service/mongodb_node.rb
+++ b/src/services/ng/mongodb/lib/mongodb_service/mongodb_node.rb
@@ -191,7 +191,8 @@ class VCAP::Services::MongoDB::Node
       "password" => password,
       "name"     => p_service.name,
       "db"       => p_service.db,
-      "url"      => "mongodb://#{username}:#{password}@#{host}:#{p_service.port}/#{p_service.db}"
+      "url"      => "mongodb://#{username}:#{password}@#{host}:#{p_service.port}/#{p_service.db}",
+      "uri"      => "mongodb://#{username}:#{password}@#{host}:#{p_service.port}/#{p_service.db}"
     }
 
     @logger.debug("Bind response: #{response}")


### PR DESCRIPTION
Hi

Similarly to PR #123 there should be a credential attribute called uri for the MongoDB service.