### PR TITLE
Use ruby under packages, instead of /var/vcap/bosh/bin/ruby

### DIFF
--- a/packages/postgresql_node_ng/packaging
+++ b/packages/postgresql_node_ng/packaging
@@ -5,6 +5,8 @@ cp -a * ${BOSH_INSTALL_TARGET}
 rm ${BOSH_INSTALL_TARGET}/packaging
 
 (
+  export PATH=/var/vcap/packages/ruby_next/bin:$PATH
+  
   cd ${BOSH_INSTALL_TARGET}/postgresql
   /var/vcap/packages/ruby_next/bin/bundle config build.do_sqlite3 --with-sqlite3-dir=/var/vcap/packages/sqlite
   /var/vcap/packages/ruby_next/bin/bundle config build.pg --with-pg-dir=/var/vcap/packages/postgresql

--- a/packages/rabbit_node_ng/packaging
+++ b/packages/rabbit_node_ng/packaging
@@ -4,6 +4,8 @@ set -e
 cp -a * ${BOSH_INSTALL_TARGET}
 
 (
+  export PATH=/var/vcap/packages/ruby/bin:$PATH
+  
   cd ${BOSH_INSTALL_TARGET}/services/ng/rabbit
   bundle_cmd=/var/vcap/packages/ruby/bin/bundle
   $bundle_cmd config build.do_sqlite3 --with-sqlite3-dir=/var/vcap/packages/sqlite

--- a/packages/redis_node_ng/packaging
+++ b/packages/redis_node_ng/packaging
@@ -4,6 +4,8 @@ set -e
 cp -a * ${BOSH_INSTALL_TARGET}
 
 (
+  export PATH=/var/vcap/packages/ruby_next/bin:$PATH
+  
   cd ${BOSH_INSTALL_TARGET}/services/ng/redis
   bundle_cmd=/var/vcap/packages/ruby_next/bin/bundle
   $bundle_cmd config build.do_sqlite3 --with-sqlite3-dir=/var/vcap/packages/sqlite

--- a/packages/vblob_node_ng/packaging
+++ b/packages/vblob_node_ng/packaging
@@ -4,6 +4,8 @@ set -e
 cp -a * ${BOSH_INSTALL_TARGET}
 
 (
+  export PATH=/var/vcap/packages/ruby/bin:$PATH
+
   cd ${BOSH_INSTALL_TARGET}/services/ng/vblob
   bundle_cmd=/var/vcap/packages/ruby/bin/bundle
   $bundle_cmd config build.do_sqlite3 --with-sqlite3-dir=/var/vcap/packages/sqlite


### PR DESCRIPTION
The /var/vcap/bosh/bin/ruby is a very old version, and BOSH team has plan to remove it from stemcell, after removing the ruby from stemcell, the packages in this PR failed to be compiled with error:

, Stderr: + cp -a common packaging pkg_utils services warden /var/vcap/packages/rabbit_node_ng
+ cd /var/vcap/packages/rabbit_node_ng/services/ng/rabbit
+ bundle_cmd=/var/vcap/packages/ruby/bin/bundle
+ /var/vcap/packages/ruby/bin/bundle config build.do_sqlite3 --with-sqlite3-dir=/var/vcap/packages/sqlite
+ /var/vcap/packages/ruby/bin/bundle install --local --deployment
+ cd /var/vcap/packages/rabbit_node_ng/warden
+ /var/vcap/packages/ruby/bin/bundle install --local --deployment --without=development test
+ /var/vcap/packages/ruby/bin/bundle exec rake setup:bin
/usr/bin/env: ruby: No such file or directory
