### PR TITLE
Correct deployment failures for bosh-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Creating service my-mongodb in org <org> / space <space> as <user>...
 OK
 ```
 
+If you're using bosh-lite, and have used the warden deployment manifest, you can authorize your services by executing:
+```
+$ rake setup
+```
+
 Repository Contents
 -------------------
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 desc "Setup cf for running specs"
 task :setup do
-  sh "cf api api.10.244.0.34.xip.io --skip-ssl-validation"
+  sh "cf api api.bosh-lite.com --skip-ssl-validation"
   sh "cf auth admin admin"
   sh "cf create-org services"
   sh "cf create-space contrib -o services"

--- a/templates/infrastructure-warden.yml
+++ b/templates/infrastructure-warden.yml
@@ -14,9 +14,9 @@ update:
 
 properties:
   cc:
-    srv_api_uri: http://api.10.244.0.34.xip.io
+    srv_api_uri: http://api.bosh-lite.com
 
-  uaa_endpoint: http://uaa.10.244.0.34.xip.io
+  uaa_endpoint: http://uaa.bosh-lite.com
 
   uaa_client_auth_credentials:
     username: admin


### PR DESCRIPTION
I was running into the same issues described in https://github.com/cloudfoundry-community/cf-services-contrib-release/issues/163 and https://github.com/cloudfoundry-community/cf-services-contrib-release/issues/154.

I was able to fix them by updating url references from `10.244.0.34.xip.io` to `bosh-lite.com` as well as  running `rake setup`.