### PR TITLE
Update omni-uaa-auth.  Resolve gems download URL

### DIFF
--- a/src/pkg_utils/fetch_gems
+++ b/src/pkg_utils/fetch_gems
@@ -72,7 +72,7 @@ to_fetch.map do |gem_basename|
       next
     end
     File.open(cached, "wb") do |file|
-      uri = URI.parse("http://production.s3.rubygems.org/gems/#{gem_basename}")
+      uri = URI.parse("http://rubygems.global.ssl.fastly.net/gems/#{gem_basename}")
       download(uri, file)
     end
     FileUtils.copy(cached, target)

--- a/src/services/tools/servicesmgmt/Gemfile
+++ b/src/services/tools/servicesmgmt/Gemfile
@@ -6,7 +6,7 @@ gem "rack-proxy"
 gem "sinatra"
 gem "sinatra-contrib"
 gem "yajl-ruby"
-gem "omniauth-uaa-oauth2", :git => "git://github.com/cloudfoundry/omniauth-uaa-oauth2.git", :ref => "ffa3468e93"
+gem "omniauth-uaa-oauth2", :git => "git://github.com/cloudfoundry/omniauth-uaa-oauth2.git", :ref => "f892fd3415"
 gem "vcap_logging", :require => ["vcap/logging"], :git => "git://github.com/cloudfoundry/common.git", :ref => "b96ec1192"
 gem "cfoundry", :git => "git://github.com/cloudfoundry/vmc-lib.git", :submodules => true
 

--- a/src/services/tools/servicesmgmt/Gemfile.lock
+++ b/src/services/tools/servicesmgmt/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: git://github.com/cloudfoundry/omniauth-uaa-oauth2.git
-  revision: ffa3468e93952f9f878524dabb1b6d909ba3e9fb
-  ref: ffa3468e93
+  revision: f892fd3415f9e45e678b50bc6d8b391ad7509838
+  ref: f892fd3415
   specs:
-    omniauth-uaa-oauth2 (0.0.3)
+    omniauth-uaa-oauth2 (0.0.6)
       cf-uaa-lib
       cf-uaa-lib
       omniauth (~> 1.0)


### PR DESCRIPTION
The onmi-uaa-auth had issues building using newer versions of Ruby.

The update to use the 0.0.6 version solves this problem.

Secondly the gem download directory production.s3.rubygems.org is not valid.  We used a backup server to make sure gems are able to be downloaded.